### PR TITLE
Minor update to toolbox panel grid

### DIFF
--- a/src/components/Toolbox.tsx
+++ b/src/components/Toolbox.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Panel } from './Panel';
 
 import '../css/toolbox.css';
 import { ToolboxTerrainPanel } from './Toolbox/ToolboxTerrainPanel';

--- a/src/components/Toolbox/ToolboxTerrainPanel.tsx
+++ b/src/components/Toolbox/ToolboxTerrainPanel.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import '../../css/toolbox.css';
 import { Tile } from './toolboxTypes';
 import { Panel } from '../Panel';
 import { ToolboxPanelGrid } from './ToolboxPanelGrid';

--- a/src/css/toolbox-panel-grid.css
+++ b/src/css/toolbox-panel-grid.css
@@ -1,5 +1,9 @@
 .toolbox-panel-grid-tile {
+  border: 1px solid #ccc;
   cursor: pointer;
   display: inline-block;
-  margin: 5px;
+  height: 48px;
+  margin: 4px;
+  text-align: center;
+  width: 48px;
 }


### PR DESCRIPTION
Minor update to toolbox panel grid to set the size of the icons to 48x48 pixles for now with a light border