### PR TITLE
Render images in toolbox without interpolation

### DIFF
--- a/src/css/toolbox-panel-grid.css
+++ b/src/css/toolbox-panel-grid.css
@@ -11,3 +11,12 @@
   text-align: center;
   width: 48px;
 }
+
+.toolbox-panel-grid-tile img {
+  image-rendering: optimizeSpeed;
+  image-rendering: -moz-crisp-edges;
+  image-rendering: -webkit-optimize-contrast;
+  image-rendering: optimize-contrast;
+  image-rendering: pixelated;
+  -ms-interpolation-mode: nearest-neighbor;
+}


### PR DESCRIPTION
Fixes the images in the toolbox so that they don't render with interpolation (which was causing the blurriness). This doesn't work in Edge because Edge removed support for it.