### PR TITLE
Undo/Redo part 2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,17 +3,18 @@
 import * as React from 'react';
 
 import { pxt, PXTClient } from '../lib/pxtextensions';
-import { Map } from './components/Map';
+import { Map, MapCanvas } from './components/Map';
 import { Navigator } from './components/Navigator';
 import { EditingTools } from './components/EditingTools';
 import { Toolbox } from './components/Toolbox';
 import { EmitterFactory } from "./exporter/factory";
-import { MapData, MapObjectLayers } from './map';
+import { MapData, MapObjectLayers, MapLog, ReadonlyMapData } from './map';
 import { MapTools, loadImageAsync } from './util';
 import { TileSet, TILE_SIZE } from './tileset';
 import { Tile } from './components/Toolbox/toolboxTypes';
 
 import './css/index.css'
+import { OperationLog } from './opLog';
 
 export interface AppProps {
     client: PXTClient;
@@ -29,7 +30,7 @@ export interface AppState {
 
 export class App extends React.Component<AppProps, AppState> {
 
-    protected map: MapData;
+    protected map: MapLog;
     protected tileSet: TileSet;
     constructor(props: AppProps) {
         super(props);
@@ -49,7 +50,8 @@ export class App extends React.Component<AppProps, AppState> {
                 this.setState({ tileSetLoaded: true })
             });
 
-        this.map = new MapData();
+        this.map = new OperationLog(() => new MapData(), MapCanvas.applyOperation);
+
         props.client.on('read', this.deserialize);
         props.client.on('hidden', this.serialize);
     }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -212,23 +212,28 @@ export class MapCanvas implements GestureTarget {
 
     onClick(coord: ClientCoordinates) {
         let data = null
+        let mapUpdate = false
         switch (this.tool) {
             case MapTools.Stamp:
                 data = 1
+                mapUpdate = true
                 break;
             case MapTools.Erase:
                 data = null
+                mapUpdate = true
                 break;
         }
         coord = this.clientToCanvas(coord);
 
-        let op: SetTileOp = {
-            kind: "settile",
-            row: this.canvasToMap(coord.clientX - this.offsetX),
-            col: this.canvasToMap(coord.clientY - this.offsetY),
-            data,
+        if (mapUpdate) {
+            let op: SetTileOp = {
+                kind: "settile",
+                row: this.canvasToMap(coord.clientX - this.offsetX),
+                col: this.canvasToMap(coord.clientY - this.offsetY),
+                data,
+            }
+            this.triggerOperation(op)
         }
-        this.triggerOperation(op)
     }
 
     onDragStart(coord: ClientCoordinates) {

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -274,21 +274,26 @@ export class MapCanvas implements GestureTarget {
                     if (this.bitmask.get(c, r) === 1) {
                         // TODO(dz): add a multi-tile op
                         let data: number | null;
+                        let mapUpdate = false
                         switch (this.tool) {
                             case MapTools.Stamp:
                                 data = 1
+                                mapUpdate = true
                                 break;
                             case MapTools.Erase:
                                 data = null
+                                mapUpdate = true
                                 break;
                         }
-                        let op: SetTileOp = {
-                            kind: "settile",
-                            row: c + this.canvasToMap(-this.offsetX),
-                            col: r + this.canvasToMap(-this.offsetY),
-                            data: 1
+                        if (mapUpdate) {
+                            let op: SetTileOp = {
+                                kind: "settile",
+                                row: c + this.canvasToMap(-this.offsetX),
+                                col: r + this.canvasToMap(-this.offsetY),
+                                data: data
+                            }
+                            this.log.do(op)
                         }
-                        this.log.do(op)
                     }
                 }
             }

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import '../css/navigator.css';
 import { GestureTarget, ClientCoordinates, bindGestureEvents } from '../util';
-import { MapData } from '../map';
+import { MapData, MapLog } from '../map';
 import { TileSet } from '../tileset';
 
 interface NavigatorProps {
-    map: MapData
+    map: MapLog,
     tileSet: TileSet
 }
 
@@ -19,7 +19,7 @@ export class Navigator extends React.Component<NavigatorProps, {}> {
     render() {
         return (
             <div className="navigator">
-                <canvas width="1" height="1" ref={this.handleCanvasRef}/>
+                <canvas width="1" height="1" ref={this.handleCanvasRef} />
             </div>
         );
     }
@@ -49,23 +49,27 @@ export class Navigator extends React.Component<NavigatorProps, {}> {
 export class NavigatorCanvas implements GestureTarget {
     protected context: CanvasRenderingContext2D;
 
-    constructor(protected canvas: HTMLCanvasElement, protected map: MapData, protected tileSet: TileSet) {
+    constructor(protected canvas: HTMLCanvasElement, protected log: MapLog, protected tileSet: TileSet) {
         this.context = canvas.getContext("2d");
 
         bindGestureEvents(canvas, this);
-        this.map.addChangeListener(() => this.redraw());
+        this.log.addChangeListener(() => this.redraw());
     }
 
-    setTileSet(tiles:TileSet){
-        this.tileSet=tiles;
+    map() {
+        return this.log.currentState()
+    }
+
+    setTileSet(tiles: TileSet) {
+        this.tileSet = tiles;
         this.redraw();
     }
 
     redraw() {
         window.requestAnimationFrame(() => {
-            let mapBounds = this.map.getBounds();
+            let mapBounds = this.map().getBounds();
 
-            if(!mapBounds) return;
+            if (!mapBounds) return;
 
             let mapWidth = mapBounds.right - mapBounds.left + 1;
             let mapHeight = mapBounds.bottom - mapBounds.top + 1;
@@ -82,19 +86,19 @@ export class NavigatorCanvas implements GestureTarget {
 
             this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
-            
+
 
             for (let x = 0; x < mapWidth; x++) {
                 for (let y = 0; y < mapHeight; y++) {
-                    let tile_index = this.map.getTile(
+                    let tile_index = this.map().getTile(
                         mapBounds.left + x, mapBounds.top + y);
 
                     if (!tile_index) {
                         continue
                     }
-                    
+
                     let rgb = this.tileSet.getColor(tile_index).split(' ');
-                    
+
                     let r = parseInt(rgb[0]); // Random colors
                     let g = parseInt(rgb[1]);
                     let b = parseInt(rgb[2]);
@@ -107,8 +111,8 @@ export class NavigatorCanvas implements GestureTarget {
         });
     }
 
-    onClick(coord: ClientCoordinates) {};
-    onDragStart(coord: ClientCoordinates) {};
-    onDragMove(coord: ClientCoordinates) {};
-    onDragEnd(coord: ClientCoordinates) {};
+    onClick(coord: ClientCoordinates) { };
+    onDragStart(coord: ClientCoordinates) { };
+    onDragMove(coord: ClientCoordinates) { };
+    onDragEnd(coord: ClientCoordinates) { };
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,3 +1,5 @@
+import { OperationLog } from "./opLog";
+
 export interface MapRect {
     left: number;
     top: number;
@@ -148,8 +150,30 @@ export enum MapObjectLayers {
     Area = 4
 }
 
-export class MapData {
-    protected changeListeners: (() => void)[];
+export interface ReadonlyMapData {
+    getTile(column: number, row: number): number;
+    getLayer(layer: MapObjectLayers): MapObjectLayer;
+    getLayers(): ReadonlyArray<MapObjectLayer>;
+    getBounds(): MapRect;
+}
+
+export interface SetTileOp {
+    kind: "settile",
+    row: number,
+    col: number,
+    data: number
+}
+export interface SetObjectOp {
+    kind: "setobj",
+    obj: MapObject,
+    layer: MapObjectLayers
+}
+
+export type MapOperation = SetTileOp | SetObjectOp
+
+export type MapLog = OperationLog<MapData, ReadonlyMapData, MapOperation>
+
+export class MapData implements ReadonlyMapData {
     protected ne: MapQuadrant;
     protected se: MapQuadrant;
     protected sw: MapQuadrant;
@@ -165,7 +189,6 @@ export class MapData {
         this.nw = new MapQuadrant();
 
         this.layers = [];
-        this.changeListeners = [];
 
         this.layers[MapObjectLayers.Decoration] = new MapObjectLayer();
         this.layers[MapObjectLayers.Item] = new MapObjectLayer();
@@ -195,24 +218,19 @@ export class MapData {
             this.bounds.height = this.bounds.bottom - this.bounds.top - 1;
         }
 
-        if (this.changeListeners) this.changeListeners.forEach(e => e());
     }
 
-    getTile(column: number, row: number) {
+    getTile(column: number, row: number): number {
         return this.getQuadrant(column, row).getTile(column, row);
     }
 
-    addChangeListener(cb: () => void) {
-        this.changeListeners.push(cb);
-    }
-
-    addObjectToLayer(layer: MapObjectLayers, obj: MapObject) {
+    addObjectToLayer(layer: MapObjectLayers, obj: MapObject): void {
         if (this.layers[layer]) {
             this.layers[layer].addObject(obj);
         }
     }
 
-    getLayer(layer: MapObjectLayers) {
+    getLayer(layer: MapObjectLayers): MapObjectLayer {
         return this.layers[layer];
     }
 
@@ -235,7 +253,7 @@ export class MapData {
         }
     }
 
-    getBounds() {
+    getBounds(): MapRect {
         return this.bounds;
     }
 }


### PR DESCRIPTION
refactor so MapLog holds MapData inside and all mutations must go through the log; needed for incremental undo

- Moves MapData inside of MapLog so that you can no longer mutate the MapData directly
- Adds ReadonlyMapData interface to ensure no one accidentally mutates the MapData directly.
