### PR TITLE
Correctly calculate the average color of tiles

### DIFF
--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -148,14 +148,12 @@ export class NavigatorCanvas implements GestureTarget {
                         continue
                     }
 
-                    let rgb = this.tileSet.getColor(tile_index).split(' ');
-
-                    let r = parseInt(rgb[0]); // Random colors
-                    let g = parseInt(rgb[1]);
-                    let b = parseInt(rgb[2]);
+                    let tileColor = this.tileSet.getColor(tile_index);
 
                     this.context.fillStyle = "rgba("
-                        + r + "," + g + "," + b + ", 255)";
+                        + tileColor.r + ","
+                        + tileColor.g + ","
+                        + tileColor.b + ", 255)";
                     this.context.fillRect(x * scale, y * scale, scale, scale);
                 }
             }

--- a/src/tileset.ts
+++ b/src/tileset.ts
@@ -1,4 +1,4 @@
-import { ClientCoordinates } from "./util";
+import { ClientCoordinates, Color } from "./util";
 import { array, number } from "prop-types";
 
 export const TILE_SIZE = 16;
@@ -7,53 +7,61 @@ export class TileSet {
     columns: number;
     rows: number;
     tileSize: number;
-    colors: String[];
+    colors: Color[];
 
     constructor(public readonly src: HTMLImageElement, tileSize?: number) {
         this.tileSize = tileSize || TILE_SIZE;
         this.columns = Math.floor(src.width / (this.tileSize));
         this.rows = Math.floor(src.height / (this.tileSize));
         this.colors = [];
+
         //call computing avg color for each tile - double for loop
         const canvas = document.createElement("canvas");
+        canvas.width = src.width;
+        canvas.height = src.height;
         const ctx = canvas.getContext('2d');
+
         ctx.drawImage(src, 0, 0, src.width, src.height);
-        for (let x = 0; x<this.rows; x++){
-            for (let y = 0; y<this.columns; y++){
-                 this.colors.push(this.computeAvgColor(ctx, x, y));
+        for (let row = 0; row < this.rows; row++) {
+            for (let col = 0; col < this.columns; col++) {
+                 this.colors.push(this.computeAvgColor(ctx, row, col));
             }
         }
     }
 
     //index to color
-    getColor(int: number):String{
+    getColor(int: number): Color {
         return this.colors[int];
     }
 
     //computing avg color - takes in HTML Image Element
-    computeAvgColor(ctx:CanvasRenderingContext2D, x: number, y: number):String{
-        let imageColor = ctx.getImageData(y*this.tileSize, x*this.tileSize, this.tileSize, this.tileSize);
-        let r = 0;
-        let g = 0;
-        let b = 0;
-        let iter = 0;
-        for (let k = 0; k<this.tileSize*this.tileSize; k+=4){
-            r += imageColor.data[k];
-            g += imageColor.data[k+1];
-            b += imageColor.data[k+2];
-            iter++;
-        }
-        r/=iter;
-        g/=iter;
-        b/=iter;
-        let rgb = "";
-        rgb += r;
-        rgb += " ";
-        rgb += g;
-        rgb += " ";
-        rgb += b;
-        return rgb;
+    computeAvgColor(
+            ctx: CanvasRenderingContext2D, row: number, col: number): Color {
+        let tile = ctx.getImageData(
+            col * this.tileSize,
+            row * this.tileSize,
+            this.tileSize,
+            this.tileSize
+        );
 
+        let color: Color = {r: 0, g: 0, b: 0};
+
+        let tilePixels = this.tileSize * this.tileSize;
+
+        if (row == 9)
+            console.log(tile.data);
+
+        for (let k = 0; k < tilePixels; k++) {
+            color.r += tile.data[4 * k];
+            color.g += tile.data[4 * k + 1];
+            color.b += tile.data[4 * k + 2];
+        }
+
+        color.r /= tilePixels;
+        color.g /= tilePixels;
+        color.b /= tilePixels;
+
+        return color;
     }
 
     indexToCoord(index: number): ClientCoordinates {

--- a/src/util.ts
+++ b/src/util.ts
@@ -222,3 +222,5 @@ export function bindGestureEvents(el: HTMLElement, target: GestureTarget) {
         el.addEventListener(evId, startGesture);
     });
 }
+
+export interface Color { r: number, g: number, b: number, a?: number }


### PR DESCRIPTION
* Not all pixels of the tiles were being used in the calculation
* Canvas was not resized, so some tiles ended up outside of the buffer
and their color wasn't correctly calculated

Before
![Screenshot from 2019-07-24 16-01-59](https://user-images.githubusercontent.com/19274477/61834776-107f0800-ae2e-11e9-9a07-6045b243564d.png)

Fixed
![Screenshot from 2019-07-24 16-01-40](https://user-images.githubusercontent.com/19274477/61834715-d6156b00-ae2d-11e9-928f-b3f9b49d7644.png)

