### PR TITLE
Adds snapshotting to undo/redo for better undo performance

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -38,7 +38,7 @@ export class Map extends React.Component<MapProps, MapState> {
         return (
             <div className="map">
                 <canvas ref={this.handleCanvasRef} />
-                { (this.state.canvasCoordinates) && <div className="coordinate">{this.state.canvasCoordinates.column}, {this.state.canvasCoordinates.row}</div> }
+                {(this.state.canvasCoordinates) && <div className="coordinate">{this.state.canvasCoordinates.column}, {this.state.canvasCoordinates.row}</div>}
                 <div className="zoom">
                     <span ref="minus" className="fas fa-minus-square fa-lg" onClick={(event) => this.workspace.zoomIn(false)}></span>
                     <span ref="plus" className="fas fa-plus-square fa-lg" onClick={(event) => this.workspace.zoomIn(true)}></span>
@@ -125,10 +125,10 @@ export class MapCanvas implements GestureTarget, EditorToolHost {
     protected onRectChange: (rect: MapRect) => void;
 
     constructor(
-            protected canvas: HTMLCanvasElement,
-            protected log: MapLog,
-            protected tileSet: TileSet,
-            protected selectedTiles: MapRect,
+        protected canvas: HTMLCanvasElement,
+        protected log: MapLog,
+        protected tileSet: TileSet,
+        protected selectedTiles: MapRect,
     ) {
         this.context = canvas.getContext("2d");
         this.log.addChangeListener(() => this.redraw())
@@ -230,10 +230,6 @@ export class MapCanvas implements GestureTarget, EditorToolHost {
         this.clearCursor();
     }
 
-    private triggerOperation(op: MapOperation) {
-        this.log.do(op)
-    }
-
     static applyOperation(state: MapData, op: MapOperation): MapData {
         if (op.kind === "settile") {
             state.setTileGroup(op.col, op.row, op.selectedTiles, op.tileSet);
@@ -266,32 +262,6 @@ export class MapCanvas implements GestureTarget, EditorToolHost {
     }
 
     onClick(coord: ClientCoordinates) {
-        const canvasCoords = this.clientToCanvas(coord);
-        let data = null
-        let mapUpdate = false
-        switch (this.tool) {
-            case MapTools.Stamp:
-                data = this.selectedTiles;
-                mapUpdate = true
-                break;
-            case MapTools.Erase:
-                data = null
-                mapUpdate = true
-                break;
-        }
-
-        if (mapUpdate) {
-            let op: SetTileOp = {
-                kind: "settile",
-                row: this.canvasToMap(canvasCoords.clientY - this.offsetY),
-                col: this.canvasToMap(canvasCoords.clientX - this.offsetX),
-                tileSet: this.tileSet,
-                selectedTiles: data,
-            }
-            console.log(op);
-            this.triggerOperation(op)
-        }
-
         if (this.editorTool) this.editorTool.onClick(this.clientToEditorLocation(coord));
     }
 
@@ -377,7 +347,7 @@ export class MapCanvas implements GestureTarget, EditorToolHost {
     }
 
     visibleBounds(): MapRect {
-       return this.visibleRect();
+        return this.visibleRect();
     }
 
     pan(dx: number, dy: number) {
@@ -395,7 +365,7 @@ export class MapCanvas implements GestureTarget, EditorToolHost {
     }
 
     commitAction(action: MapOperation): void {
-        this.triggerOperation(action);
+        this.log.do(action)
         this.stagedOp = undefined;
     }
 
@@ -520,7 +490,7 @@ export class MapCanvas implements GestureTarget, EditorToolHost {
         const canvasCoords = this.clientToCanvas(coord);
 
         return {
-            column : this.canvasToMap(canvasCoords.clientX - this.offsetX),
+            column: this.canvasToMap(canvasCoords.clientX - this.offsetX),
             row: this.canvasToMap(canvasCoords.clientY - this.offsetY),
             canvasX: canvasCoords.clientX,
             canvasY: canvasCoords.clientY

--- a/src/opLog.ts
+++ b/src/opLog.ts
@@ -5,7 +5,7 @@ class RingBuffer<T> {
     constructor(public size: number) { }
 
     private wrap(idx: number, lim: number) {
-        while (idx >= lim)
+        while (lim && idx >= lim)
             idx -= lim
         return idx
     }
@@ -108,14 +108,16 @@ export class OperationLog<State extends ReadonlyState & Clonable<State>, Readonl
         // TODO(dz): if there aren't any snapshots, rebuild them
         let lastSnap = this.lastSnapshot()
         let startState;
-        if (lastSnap.state)
+        if (lastSnap && lastSnap.state)
             startState = lastSnap.state.clone()
-        if (!lastSnap)
+        if (!lastSnap) {
             lastSnap = { idx: 0, state: this.newState() }
+            startState = lastSnap.state
+        }
 
         let newState = this.log
             .slice(lastSnap.idx, this.cursor + 1)
-            .reduce(this.applyOperation, lastSnap.state)
+            .reduce(this.applyOperation, startState)
 
         this.currState = newState
 

--- a/src/opLog.ts
+++ b/src/opLog.ts
@@ -1,8 +1,13 @@
+
+
+
 export class OperationLog<State extends ReadonlyState, ReadonlyState, Operation> {
     private log: Operation[] = []
     private cursor: number = -1
     private currState: State;
     private changeListeners: ((newState?: State) => void)[] = [];
+
+    private snapshots: { cursor: number, state: State }[] // TODO: ringbuffer
 
     constructor(private newState: () => State, private applyOperation: (old: State, op: Operation) => State) {
         this.currState = newState()

--- a/src/opLog.ts
+++ b/src/opLog.ts
@@ -105,12 +105,12 @@ export class OperationLog<State extends ReadonlyState & Clonable<State>, Readonl
             this.cursor--
 
         // incremental undo by working from the last snapshot
-        // TODO(dz): if there aren't any snapshots, rebuild them
         let lastSnap = this.lastSnapshot()
         let startState;
         if (lastSnap && lastSnap.state)
             startState = lastSnap.state.clone()
         if (!lastSnap) {
+            // TODO(dz): recreate snapshots
             lastSnap = { idx: 0, state: this.newState() }
             startState = lastSnap.state
         }
@@ -129,8 +129,10 @@ export class OperationLog<State extends ReadonlyState & Clonable<State>, Readonl
             this.cursor++
 
         let op = this.currentOp()
-        this.currState = this.applyOperation(this.currState, op)
+        if (op) {
+            this.currState = this.applyOperation(this.currState, op)
 
-        this.onChange()
+            this.onChange()
+        }
     }
 }

--- a/src/opLog.ts
+++ b/src/opLog.ts
@@ -37,8 +37,9 @@ export class OperationLog<State extends ReadonlyState & Clonable<State>, Readonl
     private cursor: number = -1
     private currState: State;
     private changeListeners: ((newState?: State) => void)[] = [];
-    private snapshots = new RingBuffer<{ idx: number | null, state: State }>(5);
+    private snapshots = new RingBuffer<{ idx: number | null, state: State }>(OperationLog.SNAPSHOT_NUM);
     private static SNAPSHOT_INTERVAL: number = 10;
+    private static SNAPSHOT_NUM: number = 5;
 
     constructor(private newState: () => State, private applyOperation: (old: State, op: Operation) => State) {
         this.currState = newState()

--- a/src/opLog.ts
+++ b/src/opLog.ts
@@ -1,22 +1,53 @@
+class RingBuffer<T> {
+    private data: T[] = []
+    private next: number = 0
 
+    constructor(public size: number) { }
 
+    private wrap(idx: number, lim: number) {
+        while (idx >= lim)
+            idx -= lim
+        return idx
+    }
+
+    add(t: T) {
+        this.data[this.next] = t
+
+        this.next = this.wrap(this.next + 1, this.size)
+    }
+
+    *[Symbol.iterator]() {
+        if (!this.data.length)
+            return
+        let itr = this.wrap(this.next, this.data.length)
+        for (let n = 0; n < this.data.length; n++) {
+            yield this.data[itr]
+            itr = this.wrap(itr + 1, this.data.length)
+        }
+    }
+
+}
 
 export class OperationLog<State extends ReadonlyState, ReadonlyState, Operation> {
     private log: Operation[] = []
     private cursor: number = -1
     private currState: State;
     private changeListeners: ((newState?: State) => void)[] = [];
-
-    private snapshots: { cursor: number, state: State }[] // TODO: ringbuffer
+    private snapshots = new RingBuffer<{ idx: number | null, state: State }>(5);
 
     constructor(private newState: () => State, private applyOperation: (old: State, op: Operation) => State) {
         this.currState = newState()
     }
 
     private truncate() {
-        // DESTRUCTIVE
+        // DESTRUCTIVE. Remove/invalidate all state after the cursor (exclusive), including snapshots
         if (this.cursor < this.log.length)
             this.log.splice(this.cursor + 1)
+        for (let s of this.snapshots) {
+            if (this.cursor < s.idx) {
+                s.idx = null
+            }
+        }
     }
     private lastIdx(): number {
         return this.log.length - 1
@@ -48,18 +79,39 @@ export class OperationLog<State extends ReadonlyState, ReadonlyState, Operation>
         }
         this.log.push(op)
         this.cursor = this.lastIdx()
-
         this.currState = this.applyOperation(this.currState, op)
 
+        // TODO(dz): take snapshot
+
         this.onChange()
+    }
+
+    private lastSnapshot(): { idx: number | null, state: State } {
+        let c: { idx: number | null, state: State } = null
+        for (let s of this.snapshots) {
+            if (s.idx && s.idx <= this.cursor)
+                if (!c || c.idx < s.idx)
+                    c = s
+        }
+        return c
     }
 
     undo(): void {
         if (this.cursor >= 0)
             this.cursor--
 
-        // TODO(dz): incremental undo
-        let newState = this.computeState(this.applyOperation, this.newState());
+        // incremental undo by working from the last snapshot
+        // TODO(dz): if there aren't any snapshots, rebuild them
+        let start = this.lastSnapshot()
+        if (start)
+            start = start.clone()
+        if (!start)
+            start = { idx: 0, state: this.newState() }
+
+        let newState = this.log
+            .slice(start.idx, this.cursor + 1)
+            .reduce(this.applyOperation, start.state)
+
         this.currState = newState
 
         this.onChange()
@@ -73,9 +125,5 @@ export class OperationLog<State extends ReadonlyState, ReadonlyState, Operation>
         this.currState = this.applyOperation(this.currState, op)
 
         this.onChange()
-    }
-
-    private computeState(reduceFn: (prevState: State, nextOp: Operation) => State, defState: State): State {
-        return this.log.slice(0, this.cursor + 1).reduce(reduceFn, defState)
     }
 }


### PR DESCRIPTION
Uses a RingBuffer to store X (5) snapshots every Y (10) operations. Rebuilds state from last snapshot on undo.

The most important improvement from this PR is that "undo" performance stays constant as time in the editor goes on. Otherwise after a long edit session undo might become very slow.