### PR TITLE
Better layout in terrain panel

### DIFF
--- a/dist/tile_dungeon.json
+++ b/dist/tile_dungeon.json
@@ -2,6 +2,7 @@
     "terrain": [
         {
             "name": "purple_inner_northwest",
+            "group": "purple_wall",
             "x": 0,
             "y": 0,
             "width": 16,
@@ -9,6 +10,7 @@
         },
         {
             "name": "purple_inner_north1",
+            "group": "purple_wall",
             "x": 16,
             "y": 0,
             "width": 16,
@@ -16,6 +18,7 @@
         },
         {
             "name": "purple_inner_north2",
+            "group": "purple_wall",
             "x": 32,
             "y": 0,
             "width": 16,
@@ -23,6 +26,7 @@
         },
         {
             "name": "purple_inner_north_torch",
+            "group": "purple_wall",
             "x": 48,
             "y": 0,
             "width": 16,
@@ -30,6 +34,7 @@
         },
         {
             "name": "purple_inner_northeast",
+            "group": "purple_wall",
             "x": 64,
             "y": 0,
             "width": 16,
@@ -37,6 +42,7 @@
         },
         {
             "name": "light_tile1",
+            "group": "floor",
             "x": 80,
             "y": 0,
             "width": 16,
@@ -44,6 +50,7 @@
         },
         {
             "name": "light_tile2",
+            "group": "floor",
             "x": 96,
             "y": 0,
             "width": 16,
@@ -51,6 +58,7 @@
         },
         {
             "name": "light_tile3",
+            "group": "floor",
             "x": 112,
             "y": 0,
             "width": 16,
@@ -58,6 +66,7 @@
         },
         {
             "name": "purple_inner_west_torch",
+            "group": "purple_wall",
             "x": 0,
             "y": 16,
             "width": 16,
@@ -65,6 +74,7 @@
         },
         {
             "name": "purple_inner_east",
+            "group": "purple_wall",
             "x": 64,
             "y": 16,
             "width": 16,
@@ -72,6 +82,7 @@
         },
         {
             "name": "light_tile4",
+            "group": "floor",
             "x": 80,
             "y": 16,
             "width": 16,
@@ -79,6 +90,7 @@
         },
         {
             "name": "light_tile5",
+            "group": "floor",
             "x": 96,
             "y": 16,
             "width": 16,
@@ -86,6 +98,7 @@
         },
         {
             "name": "light_tile6",
+            "group": "floor",
             "x": 112,
             "y": 16,
             "width": 16,
@@ -121,6 +134,7 @@
         },
         {
             "name": "purple_inner_west1",
+            "group": "purple_wall",
             "x": 0,
             "y": 32,
             "width": 16,
@@ -128,6 +142,7 @@
         },
         {
             "name": "purple_outer_northwest",
+            "group": "purple_wall",
             "x": 16,
             "y": 32,
             "width": 16,
@@ -135,6 +150,7 @@
         },
         {
             "name": "purple_outer_northeast",
+            "group": "purple_wall",
             "x": 32,
             "y": 32,
             "width": 16,
@@ -142,6 +158,7 @@
         },
         {
             "name": "purple_inner_east2",
+            "group": "purple_wall",
             "x": 64,
             "y": 32,
             "width": 16,
@@ -149,6 +166,7 @@
         },
         {
             "name": "dark_tile1",
+            "group": "floor",
             "x": 80,
             "y": 32,
             "width": 16,
@@ -156,6 +174,7 @@
         },
         {
             "name": "dark_tile2",
+            "group": "floor",
             "x": 96,
             "y": 32,
             "width": 16,
@@ -163,6 +182,7 @@
         },
         {
             "name": "dark_tile3",
+            "group": "floor",
             "x": 112,
             "y": 32,
             "width": 16,
@@ -170,6 +190,7 @@
         },
         {
             "name": "purple_inner_west2",
+            "group": "purple_wall",
             "x": 0,
             "y": 48,
             "width": 16,
@@ -177,6 +198,7 @@
         },
         {
             "name": "purple_outer_southwest",
+            "group": "purple_wall",
             "x": 16,
             "y": 48,
             "width": 16,
@@ -184,6 +206,7 @@
         },
         {
             "name": "purple_outer_southeast",
+            "group": "purple_wall",
             "x": 32,
             "y": 48,
             "width": 16,
@@ -191,6 +214,7 @@
         },
         {
             "name": "purple_inner_east_torch",
+            "group": "purple_wall",
             "x": 64,
             "y": 48,
             "width": 16,
@@ -198,6 +222,7 @@
         },
         {
             "name": "dark_tile4",
+            "group": "floor",
             "x": 80,
             "y": 48,
             "width": 16,
@@ -205,6 +230,7 @@
         },
         {
             "name": "dark_tile5",
+            "group": "floor",
             "x": 96,
             "y": 48,
             "width": 16,
@@ -212,6 +238,7 @@
         },
         {
             "name": "dark_tile6",
+            "group": "floor",
             "x": 112,
             "y": 48,
             "width": 16,
@@ -247,6 +274,7 @@
         },
         {
             "name": "purple_inner_southwest",
+            "group": "purple_wall",
             "x": 0,
             "y": 64,
             "width": 16,
@@ -254,6 +282,7 @@
         },
         {
             "name": "purple_inner_south_torch",
+            "group": "purple_wall",
             "x": 16,
             "y": 64,
             "width": 16,
@@ -261,6 +290,7 @@
         },
         {
             "name": "purple_inner_south1",
+            "group": "purple_wall",
             "x": 32,
             "y": 64,
             "width": 16,
@@ -268,6 +298,7 @@
         },
         {
             "name": "purple_inner_south2",
+            "group": "purple_wall",
             "x": 48,
             "y": 64,
             "width": 16,
@@ -275,6 +306,7 @@
         },
         {
             "name": "purple_inner_southeast",
+            "group": "purple_wall",
             "x": 64,
             "y": 64,
             "width": 16,
@@ -282,6 +314,7 @@
         },
         {
             "name": "dark_tile7",
+            "group": "floor",
             "x": 80,
             "y": 64,
             "width": 16,
@@ -289,6 +322,7 @@
         },
         {
             "name": "light_tile7",
+            "group": "floor",
             "x": 96,
             "y": 64,
             "width": 16,
@@ -296,6 +330,7 @@
         },
         {
             "name": "light_tile8",
+            "group": "floor",
             "x": 112,
             "y": 64,
             "width": 16,
@@ -303,6 +338,7 @@
         },
         {
             "name": "green_inner_northwest",
+            "group": "green_wall",
             "x": 0,
             "y": 80,
             "width": 16,
@@ -310,6 +346,7 @@
         },
         {
             "name": "green_inner_north1",
+            "group": "green_wall",
             "x": 16,
             "y": 80,
             "width": 16,
@@ -317,6 +354,7 @@
         },
         {
             "name": "green_inner_north2",
+            "group": "green_wall",
             "x": 32,
             "y": 80,
             "width": 16,
@@ -324,6 +362,7 @@
         },
         {
             "name": "green_inner_north_torch",
+            "group": "green_wall",
             "x": 48,
             "y": 80,
             "width": 16,
@@ -331,6 +370,7 @@
         },
         {
             "name": "green_inner_northeast",
+            "group": "green_wall",
             "x": 64,
             "y": 80,
             "width": 16,
@@ -338,6 +378,7 @@
         },
         {
             "name": "dark_pattern_northwest",
+            "group": "dark_pattern",
             "x": 80,
             "y": 80,
             "width": 16,
@@ -345,6 +386,7 @@
         },
         {
             "name": "dark_pattern_north",
+            "group": "dark_pattern",
             "x": 96,
             "y": 80,
             "width": 16,
@@ -352,6 +394,7 @@
         },
         {
             "name": "dark_pattern_northeast",
+            "group": "dark_pattern",
             "x": 112,
             "y": 80,
             "width": 16,
@@ -359,6 +402,7 @@
         },
         {
             "name": "green_inner_west_torch",
+            "group": "green_wall",
             "x": 0,
             "y": 96,
             "width": 16,
@@ -366,6 +410,7 @@
         },
         {
             "name": "green_inner_east1",
+            "group": "green_wall",
             "x": 64,
             "y": 96,
             "width": 16,
@@ -373,6 +418,7 @@
         },
         {
             "name": "dark_pattern_west",
+            "group": "dark_pattern",
             "x": 80,
             "y": 96,
             "width": 16,
@@ -380,6 +426,7 @@
         },
         {
             "name": "dark_pattern",
+            "group": "dark_pattern",
             "x": 96,
             "y": 96,
             "width": 16,
@@ -387,6 +434,7 @@
         },
         {
             "name": "dark_pattern_east",
+            "group": "dark_pattern",
             "x": 112,
             "y": 96,
             "width": 16,
@@ -394,6 +442,7 @@
         },
         {
             "name": "green_inner_west1",
+            "group": "green_wall",
             "x": 0,
             "y": 112,
             "width": 16,
@@ -401,6 +450,7 @@
         },
         {
             "name": "green_outer_northwest",
+            "group": "green_wall",
             "x": 16,
             "y": 112,
             "width": 16,
@@ -408,6 +458,7 @@
         },
         {
             "name": "green_outer_northeast",
+            "group": "green_wall",
             "x": 32,
             "y": 112,
             "width": 16,
@@ -415,6 +466,7 @@
         },
         {
             "name": "green_inner_east2",
+            "group": "green_wall",
             "x": 64,
             "y": 112,
             "width": 16,
@@ -422,6 +474,7 @@
         },
         {
             "name": "dark_pattern_southwest",
+            "group": "dark_pattern",
             "x": 80,
             "y": 112,
             "width": 16,
@@ -429,6 +482,7 @@
         },
         {
             "name": "dark_pattern_south",
+            "group": "dark_pattern",
             "x": 96,
             "y": 112,
             "width": 16,
@@ -436,6 +490,7 @@
         },
         {
             "name": "dark_pattern_southeast",
+            "group": "dark_pattern",
             "x": 112,
             "y": 112,
             "width": 16,
@@ -450,6 +505,7 @@
         },
         {
             "name": "green_inner_west",
+            "group": "green_wall",
             "x": 0,
             "y": 128,
             "width": 16,
@@ -457,6 +513,7 @@
         },
         {
             "name": "green_outer_southwest",
+            "group": "green_wall",
             "x": 16,
             "y": 128,
             "width": 16,
@@ -464,6 +521,7 @@
         },
         {
             "name": "green_outer_southeast",
+            "group": "green_wall",
             "x": 32,
             "y": 128,
             "width": 16,
@@ -471,6 +529,7 @@
         },
         {
             "name": "green_inner_east_torch",
+            "group": "green_wall",
             "x": 64,
             "y": 128,
             "width": 16,
@@ -478,6 +537,7 @@
         },
         {
             "name": "dark_pattern_outer_northwest",
+            "group": "dark_pattern",
             "x": 80,
             "y": 128,
             "width": 16,
@@ -485,6 +545,7 @@
         },
         {
             "name": "dark_pattern_outer_northeast",
+            "group": "dark_pattern",
             "x": 96,
             "y": 128,
             "width": 16,
@@ -492,6 +553,7 @@
         },
         {
             "name": "water1",
+            "group": "misc",
             "x": 112,
             "y": 128,
             "width": 16,
@@ -499,6 +561,7 @@
         },
         {
             "name": "lava1",
+            "group": "misc",
             "x": 128,
             "y": 128,
             "width": 16,
@@ -506,6 +569,7 @@
         },
         {
             "name": "space1",
+            "group": "misc",
             "x": 144,
             "y": 128,
             "width": 16,
@@ -513,6 +577,7 @@
         },
         {
             "name": "green_inner_southwest",
+            "group": "green_wall",
             "x": 0,
             "y": 144,
             "width": 16,
@@ -520,6 +585,7 @@
         },
         {
             "name": "green_inner_south_torch",
+            "group": "green_wall",
             "x": 16,
             "y": 144,
             "width": 16,
@@ -527,6 +593,7 @@
         },
         {
             "name": "green_inner_south1",
+            "group": "green_wall",
             "x": 32,
             "y": 144,
             "width": 16,
@@ -534,6 +601,7 @@
         },
         {
             "name": "green_inner_south2",
+            "group": "green_wall",
             "x": 48,
             "y": 144,
             "width": 16,
@@ -541,6 +609,7 @@
         },
         {
             "name": "green_inner_southeast",
+            "group": "green_wall",
             "x": 64,
             "y": 144,
             "width": 16,
@@ -548,6 +617,7 @@
         },
         {
             "name": "dark_pattern_outer_southwest",
+            "group": "dark_pattern",
             "x": 80,
             "y": 144,
             "width": 16,
@@ -555,6 +625,7 @@
         },
         {
             "name": "dark_pattern_outer_southeast",
+            "group": "dark_pattern",
             "x": 96,
             "y": 144,
             "width": 16,
@@ -562,6 +633,7 @@
         },
         {
             "name": "water2",
+            "group": "misc",
             "x": 112,
             "y": 144,
             "width": 16,
@@ -569,6 +641,7 @@
         },
         {
             "name": "lava2",
+            "group": "misc",
             "x": 128,
             "y": 144,
             "width": 16,
@@ -576,6 +649,7 @@
         },
         {
             "name": "space2",
+            "group": "misc",
             "x": 144,
             "y": 144,
             "width": 16,

--- a/src/project.ts
+++ b/src/project.ts
@@ -121,6 +121,7 @@ export interface SpriteSheetReference {
     y: number;
     height: number;
     width: number;
+    group?: string;
     sheet?: ProjectSpriteSheet;
 }
 


### PR DESCRIPTION
Lays out the tiles based off of their relative position in the tilesheet and groups related tiles. In the future, we can do proper bin packing and make the layout a little better. This makes the multi-tile selection that @HansLehnert did usable again.

Before:

![old_terrain](https://user-images.githubusercontent.com/13754588/62415127-9e4eb600-b5d9-11e9-9bec-ad92f0dddf29.gif)


After:

![new_terrain](https://user-images.githubusercontent.com/13754588/62415124-9858d500-b5d9-11e9-9ffa-7750449b3266.gif)

